### PR TITLE
use v5.db.transport.rest to fix SSL error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ const formatStationId = i => {
 }
 
 const stationById = async id => {
-	const candidates = await (fetch(`https://2.db.transport.rest/locations?query=${id}`).then(res => res.json()))
+	const candidates = await (fetch(`https://v5.db.transport.rest/locations?query=${id}`).then(res => res.json()))
 	return candidates.find(s => (formatStationId(s.id) === formatStationId(id)) && formatStationId(id) && s.location)
 }
 
@@ -280,7 +280,7 @@ const hasLocation = s => {
 
 const geocoder = new MapboxGeocoder({
 	geocode: async (query) => {
-		const results = await (fetch(`https://2.db.transport.rest/locations?query=${query}`).then(res => res.json()))
+		const results = await (fetch(`https://v5.db.transport.rest/locations?query=${query}`).then(res => res.json()))
 		const filteredResults = results.filter(x => isLongDistanceOrRegional(x) && !isRegion(x) && hasLocation(x))
 		return filteredResults.map(toPoint)
 	},


### PR DESCRIPTION
When searching for a station I'm getting a SSL error:
```
GET https://2.db.transport.rest/locations?query=Berlin net::ERR_SSL_PROTOCOL_ERROR
```

It's working when using https://v5.db.transport.rest/